### PR TITLE
Phase handling three

### DIFF
--- a/Assets/Animation/CharacterAnimationController.controller
+++ b/Assets/Animation/CharacterAnimationController.controller
@@ -11,9 +11,6 @@ AnimatorStateTransition:
   - m_ConditionMode: 1
     m_ConditionEvent: ToRummaging
     m_EventTreshold: 0
-  - m_ConditionMode: 6
-    m_ConditionEvent: CharacterState
-    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 5102652264369541009}
   m_Solo: 0
@@ -92,6 +89,9 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: FireWeapon
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsHoldingWeapon
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 5619404690661895058}
@@ -445,9 +445,6 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 6
-    m_ConditionEvent: CharacterState
-    m_EventTreshold: 1
   - m_ConditionMode: 1
     m_ConditionEvent: IsRunning
     m_EventTreshold: 0
@@ -473,8 +470,8 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 6
-    m_ConditionEvent: CharacterState
+  - m_ConditionMode: 2
+    m_ConditionEvent: ToSitting
     m_EventTreshold: 1
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1735425602025504495}
@@ -503,6 +500,9 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   - m_ConditionMode: 1
     m_ConditionEvent: Kill
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsHoldingWeapon
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -4629935722095941057}
@@ -714,9 +714,6 @@ AnimatorStateTransition:
   - m_ConditionMode: 2
     m_ConditionEvent: ToRummaging
     m_EventTreshold: 0
-  - m_ConditionMode: 3
-    m_ConditionEvent: CharacterState
-    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1735425602025504495}
   m_Solo: 0
@@ -794,6 +791,9 @@ AnimatorStateTransition:
     m_EventTreshold: 1
   - m_ConditionMode: 1
     m_ConditionEvent: Kill
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: IsHoldingWeapon
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -787993842434452282}
@@ -919,8 +919,8 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 6
-    m_ConditionEvent: CharacterState
+  - m_ConditionMode: 2
+    m_ConditionEvent: IsRunning
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1735425602025504495}
@@ -1101,7 +1101,13 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsHoldingWeapon
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: FireWeapon
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1735425602025504495}
   m_Solo: 0
@@ -1283,9 +1289,6 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 6
-    m_ConditionEvent: CharacterState
-    m_EventTreshold: 0
   - m_ConditionMode: 2
     m_ConditionEvent: IsHoldingWeapon
     m_EventTreshold: 0
@@ -1343,6 +1346,9 @@ AnimatorStateTransition:
     m_EventTreshold: 2
   - m_ConditionMode: 1
     m_ConditionEvent: Kill
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsHoldingWeapon
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -6461407533603856502}

--- a/Assets/Mesh/Character/Civilian/Civilian_07.fbx.meta
+++ b/Assets/Mesh/Character/Civilian/Civilian_07.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 424fb219cdbb45f4dbc2177e393b8eb4
 ModelImporter:
-  serializedVersion: 22200
+  serializedVersion: 21100
   internalIDToNameTable: []
   externalObjects:
   - first:
@@ -24,7 +24,6 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
-    removeConstantScaleCurves: 0
     motionNodeName: 
     rigImportErrors: 
     rigImportWarnings: 
@@ -50,12 +49,10 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
-    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
-    nodeNameCollisionStrategy: 1
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -67,7 +64,6 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
-    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -78,7 +74,6 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
-    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -573,8 +568,7 @@ ModelImporter:
     - name: mixamorig:LeftHandThumb4
       parentName: mixamorig:LeftHandThumb3
       position: {x: -0.0020959782, y: 0.02674159, z: -0.00000007599592}
-      rotation: {x: -0.000000037252907, y: -0.00000054575503, z: -0.00000040885064,
-        w: 1}
+      rotation: {x: -0.000000037252907, y: -0.00000054575503, z: -0.00000040885064, w: 1}
       scale: {x: 1, y: 0.9999999, z: 0.99999994}
     - name: mixamorig:LeftHandThumb4_end
       parentName: mixamorig:LeftHandThumb4
@@ -649,8 +643,7 @@ ModelImporter:
     - name: mixamorig:LeftHandRing4
       parentName: mixamorig:LeftHandRing3
       position: {x: -0.0000326018, y: 0.024457209, z: 0.00000013746}
-      rotation: {x: -0.0000000034225425, y: 0.000000031689517, z: 0.00000038991294,
-        w: 1}
+      rotation: {x: -0.0000000034225425, y: 0.000000031689517, z: 0.00000038991294, w: 1}
       scale: {x: 1, y: 0.99999994, z: 1}
     - name: mixamorig:LeftHandRing4_end
       parentName: mixamorig:LeftHandRing4
@@ -795,8 +788,7 @@ ModelImporter:
     - name: mixamorig:RightHandRing4
       parentName: mixamorig:RightHandRing3
       position: {x: 0.000055950284, y: 0.023610864, z: 0.000000106573566}
-      rotation: {x: -0.000000003743708, y: -0.00000007148367, z: -0.00000031072224,
-        w: 1}
+      rotation: {x: -0.000000003743708, y: -0.00000007148367, z: -0.00000031072224, w: 1}
       scale: {x: 0.99999994, y: 0.9999999, z: 0.99999994}
     - name: mixamorig:RightHandRing4_end
       parentName: mixamorig:RightHandRing4
@@ -851,8 +843,7 @@ ModelImporter:
     - name: mixamorig:LeftToe_End
       parentName: mixamorig:LeftToeBase
       position: {x: -4.848698e-10, y: 0.06070331, z: -4.842877e-10}
-      rotation: {x: -0.00000010602525, y: 0.00000030349472, z: -0.00000028370414,
-        w: 1}
+      rotation: {x: -0.00000010602525, y: 0.00000030349472, z: -0.00000028370414, w: 1}
       scale: {x: 1.0000001, y: 1, z: 1.0000001}
     - name: mixamorig:LeftToe_End_end
       parentName: mixamorig:LeftToe_End
@@ -882,8 +873,7 @@ ModelImporter:
     - name: mixamorig:RightToe_End
       parentName: mixamorig:RightToeBase
       position: {x: 0.0000000126659865, y: 0.060042307, z: 0.000000002980232}
-      rotation: {x: -0.000000047963113, y: 0.00000022799941, z: 0.0000000059371814,
-        w: 1}
+      rotation: {x: -0.000000047963113, y: 0.00000022799941, z: 0.0000000059371814, w: 1}
       scale: {x: 1, y: 1, z: 1}
     - name: mixamorig:RightToe_End_end
       parentName: mixamorig:RightToe_End
@@ -907,15 +897,12 @@ ModelImporter:
     hasTranslationDoF: 0
     hasExtraRoot: 0
     skeletonHasParents: 1
-  lastHumanDescriptionAvatarSource: {fileID: 9000000, guid: 241f072c5d3c8724fafab629ca2ba44b,
-    type: 3}
+  lastHumanDescriptionAvatarSource: {fileID: 9000000, guid: 241f072c5d3c8724fafab629ca2ba44b, type: 3}
   autoGenerateAvatarMappingIfUnspecified: 1
   animationType: 3
   humanoidOversampling: 1
   avatarSetup: 2
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
-  importBlendShapeDeformPercent: 1
-  remapMaterialsIfMaterialImportModeIsNone: 0
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/Assets/Scenes/Hospital.unity
+++ b/Assets/Scenes/Hospital.unity
@@ -2832,7 +2832,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232110797876142, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 3283541368383063160, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Speed
@@ -3896,7 +3896,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232110797876142, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 3283541368383063160, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Speed
@@ -6112,7 +6112,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232110797876142, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 3283541368383063160, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Speed
@@ -12131,7 +12131,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232110797876142, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 3034232110797876142, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -14833,6 +14833,10 @@ PrefabInstance:
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Receptionist
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439130266841364, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_RootOrder
@@ -21083,7 +21087,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232110797876142, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 3283541368383063160, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Speed

--- a/Assets/Scenes/Hospital.unity
+++ b/Assets/Scenes/Hospital.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028292, g: 0.22571306, b: 0.30692118, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2051,6 +2051,10 @@ PrefabInstance:
       value: Civilian (2)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -2060,11 +2064,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 29.34
+      value: -260.97
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2999,6 +3003,10 @@ PrefabInstance:
       value: Civilian (12)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -3219,6 +3227,10 @@ PrefabInstance:
       value: Civilian (9)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -3228,11 +3240,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 20.2
+      value: -270.11
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3690,6 +3702,10 @@ PrefabInstance:
       value: Civilian (10)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -3699,11 +3715,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 16.3
+      value: -274.01
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4940,6 +4956,10 @@ PrefabInstance:
       value: Doctor (2)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Medicals
       objectReference: {fileID: 0}
@@ -5266,6 +5286,10 @@ PrefabInstance:
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Name
       value: Civilian (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
@@ -5643,6 +5667,10 @@ PrefabInstance:
       value: Civilian (4)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -5652,11 +5680,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 21.1
+      value: -269.21
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5767,6 +5795,10 @@ PrefabInstance:
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Name
       value: Civilian (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
@@ -6284,6 +6316,10 @@ PrefabInstance:
       value: Civilian (7)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -6293,11 +6329,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 19.3
+      value: -271.01
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -6460,6 +6496,10 @@ PrefabInstance:
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Name
       value: Doctor (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
@@ -7848,8 +7888,16 @@ PrefabInstance:
       value: -0.41
       objectReference: {fileID: 0}
     - target: {fileID: -8378785256492329836, guid: f34181e0f7c78db45a2d0056636ebad6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8378785256492329836, guid: f34181e0f7c78db45a2d0056636ebad6, type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.46
+      objectReference: {fileID: 0}
+    - target: {fileID: -8378785256492329836, guid: f34181e0f7c78db45a2d0056636ebad6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.18
       objectReference: {fileID: 0}
     - target: {fileID: -8314451111111470286, guid: f34181e0f7c78db45a2d0056636ebad6, type: 3}
       propertyPath: m_LocalScale.x
@@ -10433,6 +10481,10 @@ PrefabInstance:
       value: Doctor (1)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Medicals
       objectReference: {fileID: 0}
@@ -10790,6 +10842,10 @@ PrefabInstance:
       value: Nurse (1)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Medicals
       objectReference: {fileID: 0}
@@ -11109,6 +11165,10 @@ PrefabInstance:
       value: Civilian (6)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -11118,11 +11178,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 20.3
+      value: -270.01
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -11401,6 +11461,10 @@ PrefabInstance:
       value: Doctor (3)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Medicals
       objectReference: {fileID: 0}
@@ -11565,6 +11629,10 @@ PrefabInstance:
       value: Civilian (8)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -11574,11 +11642,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 16.9
+      value: -273.41
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -12178,6 +12246,10 @@ PrefabInstance:
       value: Civilian (18)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -12355,6 +12427,10 @@ PrefabInstance:
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Name
       value: Civilian (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
@@ -12822,6 +12898,10 @@ PrefabInstance:
       value: Civilian (5)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -12831,11 +12911,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 16.1
+      value: -274.21
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -15381,6 +15461,10 @@ PrefabInstance:
       value: Civilian (13)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -15906,6 +15990,10 @@ PrefabInstance:
       value: Civilian (14)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -16051,6 +16139,10 @@ PrefabInstance:
       value: Civilian (3)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -16060,11 +16152,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 29.22
+      value: -261.09
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -16863,6 +16955,10 @@ PrefabInstance:
       value: Civilian (17)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Civilians
       objectReference: {fileID: 0}
@@ -16880,7 +16976,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -12.1
+      value: -42.34
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -17106,11 +17202,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 31.31
+      value: -259
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19
+      value: -1730
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
@@ -17310,6 +17406,10 @@ PrefabInstance:
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Name
       value: Civilian (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
@@ -17647,6 +17747,10 @@ PrefabInstance:
       value: Doctor (6)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Medicals
       objectReference: {fileID: 0}
@@ -17664,7 +17768,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -15.059998
+      value: -45.3
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -20307,6 +20411,10 @@ PrefabInstance:
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Name
       value: Lab Tech
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
@@ -22963,6 +23071,10 @@ PrefabInstance:
       value: Doctor (4)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Medicals
       objectReference: {fileID: 0}
@@ -23087,6 +23199,10 @@ PrefabInstance:
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_Name
       value: Nurse (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
@@ -24135,6 +24251,10 @@ PrefabInstance:
       value: Lab Tech (Hostage)
       objectReference: {fileID: 0}
     - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2400439129582445820, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_TagString
       value: Medicals
       objectReference: {fileID: 0}
@@ -24156,7 +24276,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -11.959999
+      value: -42.2
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scenes/Hospital.unity
+++ b/Assets/Scenes/Hospital.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028292, g: 0.22571306, b: 0.30692118, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2064,15 +2064,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -260.97
+      value: 25.8
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.2
+      value: -12.6
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3240,15 +3240,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -270.11
+      value: 17.6
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 3.3
+      value: -14.1
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3715,15 +3715,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -274.01
+      value: 21.2
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 33.2
+      value: -0.7
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -5680,15 +5680,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -269.21
+      value: 20.75
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -6.7700005
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -5810,7 +5810,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.3
+      value: -1.6
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
@@ -5818,7 +5818,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 33.5
+      value: 33.65
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -6329,15 +6329,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -271.01
+      value: 20.1
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 24
+      value: 16.3
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -11178,15 +11178,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -270.01
+      value: 19.949982
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 14.2
+      value: 7.4299994
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -11642,15 +11642,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -273.41
+      value: 16.549988
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 8.2
+      value: 1.4299994
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -12911,15 +12911,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -274.21
+      value: 15.75
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.2
+      value: -6.57
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -16156,15 +16156,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -261.09
+      value: 28.869995
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 7.07
+      value: 0.29999924
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -17206,15 +17206,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -259
+      value: 28.05
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1730
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 16.9
+      value: 12.45
       objectReference: {fileID: 0}
     - target: {fileID: 3034232109503217222, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_LocalRotation.w
@@ -17271,6 +17271,14 @@ PrefabInstance:
     - target: {fileID: 3283541368383063160, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: m_AngularSpeed
       value: 360
+      objectReference: {fileID: 0}
+    - target: {fileID: 4918190580244920081, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 4918190580244920081, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.34
       objectReference: {fileID: 0}
     - target: {fileID: 7983885208073434826, guid: 0b92e6e20c22d8940b00081dc3cfda04, type: 3}
       propertyPath: speed

--- a/Assets/Scenes/Hospital.unity
+++ b/Assets/Scenes/Hospital.unity
@@ -13549,6 +13549,18 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1654711326}
     m_Modifications:
+    - target: {fileID: 7035591371690933685, guid: 3a43d1c8c6320004b8919223ef0d1d7e, type: 3}
+      propertyPath: speed
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7035591371690933685, guid: 3a43d1c8c6320004b8919223ef0d1d7e, type: 3}
+      propertyPath: maxForce
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7035591371690933685, guid: 3a43d1c8c6320004b8919223ef0d1d7e, type: 3}
+      propertyPath: maxSpeed
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7035591371690933687, guid: 3a43d1c8c6320004b8919223ef0d1d7e, type: 3}
       propertyPath: sceneId
       value: 2647749549
@@ -20262,7 +20274,7 @@ GameObject:
   - component: {fileID: 1654711326}
   - component: {fileID: 1654711327}
   m_Layer: 0
-  m_Name: Npcs
+  m_Name: Player Units
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -25099,6 +25111,18 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1654711326}
     m_Modifications:
+    - target: {fileID: 7035591371690933685, guid: 3a43d1c8c6320004b8919223ef0d1d7e, type: 3}
+      propertyPath: speed
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7035591371690933685, guid: 3a43d1c8c6320004b8919223ef0d1d7e, type: 3}
+      propertyPath: maxForce
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7035591371690933685, guid: 3a43d1c8c6320004b8919223ef0d1d7e, type: 3}
+      propertyPath: maxSpeed
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7035591371690933687, guid: 3a43d1c8c6320004b8919223ef0d1d7e, type: 3}
       propertyPath: sceneId
       value: 946518905

--- a/Assets/scripts/AIMover.cs
+++ b/Assets/scripts/AIMover.cs
@@ -280,30 +280,38 @@ public class AIMover : MonoBehaviour
         updateRotation();
     }
 
-    // Updates the animations of units depending on movement speed.
+    private bool isRunningExternally = false; // Flag to allow external running command
+
+    public void SetRunning(bool running)
+    {
+        isRunningExternally = running;
+        animator.SetBool("IsRunning", running);
+    }
+
+    // Modify UpdateAnimation to respect external running
     private void UpdateAnimation()
     {
         if (animator != null)
         {
             float currentSpeed = currentVelocity.magnitude;
-            animator.SetBool(walkingHash, currentSpeed > movementThreshhold);
 
+            if (isRunningExternally) // If externally set to run, ignore walking logic
+            {
+                animator.SetBool(walkingHash, false);
+                animator.SetBool("IsRunning", true);
+                return;
+            }
 
-            // We need to consider multiple conditions for a unit to be "stopped":
+            // Standard walking logic
             bool shouldBeIdle =
-                // Check if we've reached our destination
                 isAtDestination ||
-                // Check if velocity is effectively zero
                 currentSpeed < 0.01f ||
-                // Check if we don't have a valid path
                 path == null ||
-                // Check if we've reached the end of our path
                 currentWaypoint >= path.Count;
 
-            // Set the walking animation state based on our idle check
             animator.SetBool(walkingHash, !shouldBeIdle);
+            animator.SetBool("IsRunning", false);
 
-            // If we are going to idle, make sure to zero out the NPC velocity.
             if (shouldBeIdle)
             {
                 currentVelocity = Vector3.zero;
@@ -311,6 +319,7 @@ public class AIMover : MonoBehaviour
             }
         }
     }
+
 
 
     // Uses quaternions (to avoid gimble lock) for smooth rotations based on hit point clicked. (target location)

--- a/Assets/scripts/AIMover.cs
+++ b/Assets/scripts/AIMover.cs
@@ -9,7 +9,7 @@ public class AIMover : MonoBehaviour
     // ---- Variables for the BOIDS algorithm. ----
     [SerializeField] private float speed = 4f;
     [SerializeField] private float maxSpeed = 5f;
-    [SerializeField] private float maxForce = 4f;
+    [SerializeField] private float maxForce = 100f;
     [SerializeField] private float slowingRadius = 2f;
     [SerializeField] private float seperationRadius = 1f;
     [SerializeField] private float lookAheadDistance = 0.3f;

--- a/Assets/scripts/AIMover.cs
+++ b/Assets/scripts/AIMover.cs
@@ -81,7 +81,7 @@ public class AIMover : MonoBehaviour
         isAtDestination = true;
     }
 
-    public IEnumerator UpdatePath()
+    public IEnumerator UpdatePath(AIMover npc)
     {
         if (this == null || gameObject == null)
         {
@@ -92,7 +92,7 @@ public class AIMover : MonoBehaviour
             if (target != null)
             {
                 // Debug.Log($"Finding path from {transform.position} to {target.position}");
-                path = pathfinder.FindPath(transform.position, target.position);
+                path = pathfinder.FindPath(transform.position, target.position, npc);
                 if (path != null && path.Count > 0)
                 {
                     // Debug.Log($"Path found with {path.Count} waypoints");

--- a/Assets/scripts/HostageTriggerArea.cs
+++ b/Assets/scripts/HostageTriggerArea.cs
@@ -149,7 +149,7 @@ public class HostageTriggerArea : MonoBehaviour
             // Debug.Log("Toggling the ring to true");
             HostageRing.SetActive(true);
             Vector3 newPosition = HostageRing.transform.localPosition;
-            newPosition.y = 1f; 
+            newPosition.y = 0.3f; 
             HostageRing.transform.localPosition = newPosition;
 
             // Get the Renderer component of the ring

--- a/Assets/scripts/HostageTriggerArea.cs
+++ b/Assets/scripts/HostageTriggerArea.cs
@@ -124,6 +124,7 @@ public class HostageTriggerArea : MonoBehaviour
         {
             // Modify NPC's behavior for hostages
             // mover.StopAllMovement();
+            mover.SetRunning(false);
             mover.SetTargetPosition(transform.position);
         }
         

--- a/Assets/scripts/HostageTriggerArea.cs
+++ b/Assets/scripts/HostageTriggerArea.cs
@@ -78,7 +78,7 @@ public class HostageTriggerArea : MonoBehaviour
             return;
 
         // Check if this is a Civilian or Medical
-        if ((npc.CompareTag("Civilians") || npc.CompareTag("Medicals")) && !convertedNPCs.Contains(npc.gameObject))
+        if ((npc.CompareTag("Civilians") || npc.CompareTag("Medicals") || npc.CompareTag("Receptionist")) && !convertedNPCs.Contains(npc.gameObject))
         {
             ConvertToHostage(npc.gameObject);
         }
@@ -126,6 +126,10 @@ public class HostageTriggerArea : MonoBehaviour
             // mover.StopAllMovement();
             mover.SetRunning(false);
             mover.SetTargetPosition(transform.position);
+        } 
+        Animator animator = npc.GetComponent<Animator>();
+        if(animator != null){
+            animator.SetBool("IsThreatPresent", true);
         }
         
         // Phase 2: NPCs who are now hostages should lie down

--- a/Assets/scripts/PathRequestManager.cs
+++ b/Assets/scripts/PathRequestManager.cs
@@ -53,8 +53,8 @@ public class PathRequestManager : MonoBehaviour
     {
         // Add small delay to distribute CPU load
         yield return new WaitForEndOfFrame();
-        
-        List<Vector3> newPath = pathfinder.FindPath(currentRequest.pathStart, currentRequest.pathEnd);
+        AIMover npc = new AIMover();
+        List<Vector3> newPath = pathfinder.FindPath(currentRequest.pathStart, currentRequest.pathEnd, npc);
         currentRequest.callback(newPath);
         
         isProcessingPath = false;

--- a/Assets/scripts/Pathfinder.cs
+++ b/Assets/scripts/Pathfinder.cs
@@ -154,7 +154,7 @@ public class Pathfinder : MonoBehaviour
         var closedSet = new HashSet<GridNode>();
         
         // Set maximum iterations to prevent infinite loops
-        const int MAX_ITERATIONS = 5000;
+        const int MAX_ITERATIONS = 50000;
         int iterations = 0;
 
         startNode.GCost = 0; // Reset start node's cost
@@ -165,14 +165,14 @@ public class Pathfinder : MonoBehaviour
 
         while (openSet.Count > 0)
         {
-            // iterations++;
+            iterations++;
             
-            // // Check if we've exceeded maximum iterations
-            // if (iterations > MAX_ITERATIONS)
-            // {
-            //     Debug.LogWarning($"Pathfinding exceeded {MAX_ITERATIONS} iterations - terminating search (feel free to disable if causing issues)");
-            //     return null; // Fallback to simple path
-            // }
+            // Check if we've exceeded maximum iterations
+            if (iterations > MAX_ITERATIONS)
+            {
+                Debug.LogWarning($"Pathfinding exceeded {MAX_ITERATIONS} iterations - terminating search (feel free to disable if causing issues)");
+                return null; // Fallback to simple path
+            }
             
             // Get node with lowest FCost
             var currentNode = openSet.Dequeue();
@@ -236,7 +236,7 @@ public class Pathfinder : MonoBehaviour
             // Check if open set is too large (another sign of a difficult/impossible path)
             if (openSet.Count > navMesh.GridSizeX * navMesh.GridSizeY / 2)
             {
-                Debug.Log("Open set too large - likely impossible path");
+                Debug.LogError("Open set too large - likely impossible path");
                 return null; // Fallback to simple path
             }
         }

--- a/Assets/scripts/Pathfinder.cs
+++ b/Assets/scripts/Pathfinder.cs
@@ -116,7 +116,7 @@ public class Pathfinder : MonoBehaviour
         return simplePath;
     }
 
-    public List<Vector3> FindPath(Vector3 startPos, Vector3 targetPos)
+    public List<Vector3> FindPath(Vector3 startPos, Vector3 targetPos, AIMover npc)
     {
         var pathKey = GetPathKey(startPos, targetPos);
         // Check if the path is already contained in the cache.
@@ -137,9 +137,10 @@ public class Pathfinder : MonoBehaviour
         // Check if start position is valid
         if (startNode == null || !startNode.IsWalkable)
         {
-            Debug.LogError("Start position is unwalkable - path impossible from " + startPos + " or [" + startNode?.GridX + ", " + startNode?.GridY + "]");
+            Debug.LogError("Start position is unwalkable - path impossible from " + startPos + " or [" + startNode?.GridX + ", " + startNode?.GridY + "]"
+             + "for npc: " + npc.ToString());
             Vector3 temp = returnToSafety(GetBigNeighbors(startNode)).WorldPosition;
-            return FindLongDistancePath(startPos, temp);
+            return FindPath(temp, targetPos, npc);
         }
         
         // Check if target is the same as start (no need to pathfind)
@@ -241,7 +242,7 @@ public class Pathfinder : MonoBehaviour
             }
         }
 
-        Debug.Log("No path found after exhaustive search");
+        Debug.Log("No path found after exhaustive search for npc: " + npc.ToString());
         return null; // No path found
     }
 
@@ -308,6 +309,7 @@ public class Pathfinder : MonoBehaviour
                 return node;
             }
         }
+        Debug.LogError("Couldnt find valid neighbor");
         return null;
     }
 

--- a/Assets/scripts/Pathfinder.cs
+++ b/Assets/scripts/Pathfinder.cs
@@ -242,7 +242,7 @@ public class Pathfinder : MonoBehaviour
             }
         }
 
-        Debug.Log("No path found after exhaustive search for npc: " + npc.ToString());
+        Debug.LogWarning("No path found after exhaustive search for npc: " + npc.ToString());
         return null; // No path found
     }
 

--- a/Assets/scripts/Pathfinder.cs
+++ b/Assets/scripts/Pathfinder.cs
@@ -154,7 +154,7 @@ public class Pathfinder : MonoBehaviour
         var closedSet = new HashSet<GridNode>();
         
         // Set maximum iterations to prevent infinite loops
-        const int MAX_ITERATIONS = 1000;
+        const int MAX_ITERATIONS = 5000;
         int iterations = 0;
 
         startNode.GCost = 0; // Reset start node's cost
@@ -165,12 +165,12 @@ public class Pathfinder : MonoBehaviour
 
         while (openSet.Count > 0)
         {
-            iterations++;
+            // iterations++;
             
-            // Check if we've exceeded maximum iterations
+            // // Check if we've exceeded maximum iterations
             // if (iterations > MAX_ITERATIONS)
             // {
-            //     // Debug.LogWarning($"Pathfinding exceeded {MAX_ITERATIONS} iterations - terminating search");
+            //     Debug.LogWarning($"Pathfinding exceeded {MAX_ITERATIONS} iterations - terminating search (feel free to disable if causing issues)");
             //     return null; // Fallback to simple path
             // }
             
@@ -234,11 +234,11 @@ public class Pathfinder : MonoBehaviour
             }
             
             // Check if open set is too large (another sign of a difficult/impossible path)
-            // if (openSet.Count > navMesh.GridSizeX * navMesh.GridSizeY / 2)
-            // {
-            //     Debug.Log("Open set too large - likely impossible path");
-            //     return null; // Fallback to simple path
-            // }
+            if (openSet.Count > navMesh.GridSizeX * navMesh.GridSizeY / 2)
+            {
+                Debug.Log("Open set too large - likely impossible path");
+                return null; // Fallback to simple path
+            }
         }
 
         Debug.Log("No path found after exhaustive search");

--- a/Assets/scripts/PhaseManager.cs
+++ b/Assets/scripts/PhaseManager.cs
@@ -24,7 +24,6 @@ public class PhaseManager : MonoBehaviour
     // private GameObject superVillain;
     private GameObject receptionist;
     private int egress;
-    private bool egressPhaseSelected = false;
     public delegate void EgressSelectedHandler(int egressPhase);
     public static event EgressSelectedHandler OnEgressSelected;
 
@@ -393,7 +392,7 @@ public class PhaseManager : MonoBehaviour
                     currentPhaseCoroutine = null;
                 }
                 
-                // Select a medical NPC to be the physician hostage
+                // Select a medical NPC to be the physician hostage (thats it for this phase lol)
                 GameObject[] hostages = GameObject.FindGameObjectsWithTag("Hostages");
                 if (hostages.Length > 0) {
                     foreach (GameObject hostage in hostages) {
@@ -435,10 +434,12 @@ public class PhaseManager : MonoBehaviour
                     npcMove.MoveNPCToTarget(villainsInside[1], NPCPosition);
                     
                     // Move hostage to gamma knife
-                    NPCPosition = new Vector3(-14.3f, 0, 65.4f);
+                    NPCPosition = new Vector3(-15.6f, 0, 65f);
                     npcMove.MoveNPCToTarget(physicianHostage, NPCPosition);
                     
                     Debug.Log($"Two villains are taking {physicianHostage.name} to the gamma knife room");
+                    // Start the work on the gamma knife
+                    StartCoroutine(WorkOnGammaKnife(physicianHostage, NPCPosition));
                 }
                 
                 // Outside villains move inside to reinforce
@@ -463,8 +464,6 @@ public class PhaseManager : MonoBehaviour
                     Debug.Log($"{villainsInside[2].name} stays behind in the lobby");
                 }
                 
-                // Start the work on the gamma knife
-                StartCoroutine(WorkOnGammaKnife());
                 
                 break;
             case GamePhase.Phase5:
@@ -576,11 +575,31 @@ public class PhaseManager : MonoBehaviour
         return new Vector3(x, center.y, z);
     }
     
-    private IEnumerator WorkOnGammaKnife()
+    private IEnumerator WorkOnGammaKnife(GameObject villain, Vector3 targetposition)
     {
-        yield return new WaitForSeconds(3f); // Wait a bit for NPCs to reach positions
+        // Debug.Log("Started WorkOnGammaKnife Coroutine");
+
+        while (Vector3.Distance(villain.transform.position, targetposition) > 1f)
+        {
+            // Debug.Log($"Waiting... Current Pos: {villain.transform.position}, Target: {targetposition}");
+            yield return new WaitForSeconds(3f);
+        }
+
         Debug.Log("The villain is working on the gamma knife source!");
+        
+        Animator animator = villain.GetComponent<Animator>();
+        if (animator != null)
+        {
+            // Debug.Log("Animator found! Changing states.");
+            animator.SetBool("IsWalking", false);
+            animator.SetBool("ToRummaging", true);
+        }
+        else
+        {
+            Debug.LogError("Animator null for rummaging");
+        }
     }
+
 
     public GamePhase GetCurrentPhase(){
         return phaseList.Current.Phase;

--- a/Assets/scripts/PhaseManager.cs
+++ b/Assets/scripts/PhaseManager.cs
@@ -375,7 +375,10 @@ public class PhaseManager : MonoBehaviour
                 }
                 
                 // Villains pull out guns
-                Debug.Log("Villains pull out long guns.");
+                foreach(GameObject villain in villains){
+                    GameObject gun = villain.transform.GetChild(2).gameObject;
+                    gun.SetActive(true);
+                }
                 
                 // Receptionist hits duress alarm
                 if (receptionist != null) {
@@ -436,10 +439,12 @@ public class PhaseManager : MonoBehaviour
                     // Move hostage to gamma knife
                     NPCPosition = new Vector3(-15.6f, 0, 65f);
                     npcMove.MoveNPCToTarget(physicianHostage, NPCPosition);
+                    Animator animator = physicianHostage.GetComponent<Animator>();
+                    if(animator != null) animator.SetBool("IsThreatPresent", false);
                     
                     Debug.Log($"Two villains are taking {physicianHostage.name} to the gamma knife room");
                     // Start the work on the gamma knife
-                    StartCoroutine(WorkOnGammaKnife(physicianHostage, NPCPosition));
+                    currentPhaseCoroutine = StartCoroutine(WorkOnGammaKnife(physicianHostage, NPCPosition));
                 }
                 
                 // Outside villains move inside to reinforce
@@ -496,6 +501,10 @@ public class PhaseManager : MonoBehaviour
                 // VFD pulls up
                 // source goes into canister into backpack
                 // all adversaries and physicianhostage group up & get ready to leave
+                if (currentPhaseCoroutine != null) {
+                    StopCoroutine(currentPhaseCoroutine);
+                    currentPhaseCoroutine = null;
+                }
                 Vector3 youMoveHere = new Vector3(0f, 0, 113f);
                 float radius = 3.5f;
                 npcMove.MoveNPCToTarget(physicianHostage, youMoveHere);
@@ -575,19 +584,19 @@ public class PhaseManager : MonoBehaviour
         return new Vector3(x, center.y, z);
     }
     
-    private IEnumerator WorkOnGammaKnife(GameObject villain, Vector3 targetposition)
+    private IEnumerator WorkOnGammaKnife(GameObject npc, Vector3 targetposition)
     {
         // Debug.Log("Started WorkOnGammaKnife Coroutine");
 
-        while (Vector3.Distance(villain.transform.position, targetposition) > 1f)
+        while (Vector3.Distance(npc.transform.position, targetposition) > 1f)
         {
-            // Debug.Log($"Waiting... Current Pos: {villain.transform.position}, Target: {targetposition}");
+            // Debug.Log($"Waiting... Current Pos: {npc.transform.position}, Target: {targetposition}");
             yield return new WaitForSeconds(3f);
         }
 
         Debug.Log("The villain is working on the gamma knife source!");
         
-        Animator animator = villain.GetComponent<Animator>();
+        Animator animator = npc.GetComponent<Animator>();
         if (animator != null)
         {
             // Debug.Log("Animator found! Changing states.");

--- a/Assets/scripts/PhaseMovementHelper.cs
+++ b/Assets/scripts/PhaseMovementHelper.cs
@@ -236,9 +236,14 @@ public class PhaseMovementHelper : MonoBehaviour
         // Set target positions for all NPCs
         foreach (GameObject npc in MoveList)
         {
-            Animator animator = npc.GetComponent<Animator>();
-            animator.SetBool("IsWalking", false);
-            animator.SetBool("IsRunning", true);
+            // Animator animator = npc.GetComponent<Animator>();
+            // animator.SetBool("IsWalking", false);
+            // animator.SetBool("IsRunning", true);
+            AIMover mover = npc.GetComponent<AIMover>();
+            if (mover != null)
+            {
+                mover.SetRunning(true); // Set the AI to run instead of walk
+            }
 
             Vector3 targetPosition = GetEdgePosition();
             targetPositions[npc] = targetPosition;
@@ -269,6 +274,7 @@ public class PhaseMovementHelper : MonoBehaviour
                 {
                     // Stop movement and clean up NPC
                     AIMover mover = npc.GetComponent<AIMover>();
+                    // mover.SetRunning(true);
                     if (mover != null)
                     {
                         // mover.StopAllMovement(); // Stop movement coroutine

--- a/Assets/scripts/PhaseMovementHelper.cs
+++ b/Assets/scripts/PhaseMovementHelper.cs
@@ -169,67 +169,15 @@ public class PhaseMovementHelper : MonoBehaviour
         isProcessingUpdates = false;
     }
 
-    // Coroutine to handle random civilian movement
-    // public IEnumerator MoveCiviliansRandomly(GamePhase currentPhase)
-    // {
-    //     PhaseManager current = FindObjectOfType<PhaseManager>();
-    //     if (current == null)
-    //     {
-    //         Debug.LogError("PhaseManager not found in scene!");
-    //         yield return null;
-    //     }
-    //     while (current.GetCurrentPhase() == GamePhase.Phase1) // Keep moving civilians until coroutine is stopped
-    //     {
-    //         // Find all civilian NPCs
-    //         GameObject[] medicals = GameObject.FindGameObjectsWithTag("Medicals");
-    //         GameObject[] hostages = GameObject.FindGameObjectsWithTag("Hostages");
-    //         List<GameObject> MoveList = new List<GameObject>(GameObject.FindGameObjectsWithTag("Civilians"));
-
-    //         // I want civilians to be more active, etc. etc.
-    //         int rand = UnityEngine.Random.Range(0, 3);
-    //         if(rand == 0){
-    //             // Debug.Log("moving medicals and hostages");
-    //             MoveList.AddRange(medicals);
-    //             MoveList.AddRange(hostages);
-    //         } else if(rand <= 1) {
-    //             // Debug.Log("Moving medicals");
-    //             MoveList.AddRange(medicals);
-    //         } 
-    //         // else Debug.Log("Moving all");
-
-    //         // Queue up NPCs for batch processing
-    //         npcUpdateQueue.Clear();
-    //         foreach (GameObject npc in MoveList)
-    //         {
-    //             // GameObject VisualRing = npc.transform.GetChild(2).gameObject;
-    //             // VisualRing.SetActive(true);
-    //             // Vector3 newPosition = VisualRing.transform.localPosition;
-    //             // newPosition.y = 1f; 
-    //             // VisualRing.transform.localPosition = newPosition;
-    //             if (npc != null && npc.activeInHierarchy)
-    //             {
-    //                 npcUpdateQueue.Enqueue(npc);
-    //             }
-    //         }
-
-    //         // Process NPCs in smaller batches
-    //         if (!isProcessingUpdates && npcUpdateQueue.Count > 0)
-    //         {
-    //             StartCoroutine(ProcessNPCUpdates());
-    //         }
-
-    //         // Wait before moving NPCs again
-    //         yield return new WaitForSeconds(randomMovementInterval + Random.Range(-1f, 1f)); // Add slight variation
-    //     }
-    // }
-
     public IEnumerator MoveToEdgeAndDespawn()
     {
         GameObject[] civilians = GameObject.FindGameObjectsWithTag("Civilians");
         GameObject[] medicals = GameObject.FindGameObjectsWithTag("Medicals");
+        GameObject[] receptionist = GameObject.FindGameObjectsWithTag("Receptionist");
 
         List<GameObject> MoveList = new List<GameObject>(civilians);
         MoveList.AddRange(medicals);
+        MoveList.AddRange(receptionist);
 
         Dictionary<GameObject, Vector3> targetPositions = new Dictionary<GameObject, Vector3>();
 

--- a/Assets/scripts/PhaseMovementHelper.cs
+++ b/Assets/scripts/PhaseMovementHelper.cs
@@ -227,6 +227,10 @@ public class PhaseMovementHelper : MonoBehaviour
         // Set target positions for all NPCs
         foreach (GameObject npc in MoveList)
         {
+            Animator animator = npc.GetComponent<Animator>();
+            animator.SetBool("IsWalking", false);
+            animator.SetBool("IsRunning", true);
+
             Vector3 targetPosition = GetEdgePosition();
             targetPositions[npc] = targetPosition;
             Rigidbody rb = npc.GetComponent<Rigidbody>();

--- a/Assets/scripts/PhaseMovementHelper.cs
+++ b/Assets/scripts/PhaseMovementHelper.cs
@@ -100,7 +100,7 @@ public class PhaseMovementHelper : MonoBehaviour
             npc.SetActive(true);
             mover.enabled = true;
             mover.SetTargetPosition(targetPosition);
-            StartCoroutine(mover.UpdatePath()); // Start movement coroutine
+            StartCoroutine(mover.UpdatePath(mover)); // Start movement coroutine
         }
         else
         {

--- a/Assets/scripts/npcMovement.cs
+++ b/Assets/scripts/npcMovement.cs
@@ -72,7 +72,7 @@ public class npcMovement : MonoBehaviour
             }
 
             commanderAI.SetTargetPosition(hit.point);
-            StartCoroutine(commanderAI.UpdatePath());
+            StartCoroutine(commanderAI.UpdatePath(commanderAI));
 
             // If a formation corutine is already running, halt.
             if (formationUpdateCoroutine != null) StopCoroutine(formationUpdateCoroutine);
@@ -115,7 +115,7 @@ public class npcMovement : MonoBehaviour
                     if (Vector3.Distance(npc.transform.position, formationSlot) > 0.5f)
                     {
                         agent.SetTargetPosition(formationSlot);
-                        if (!agent.isAtDestination) StartCoroutine(agent.UpdatePath());
+                        if (!agent.isAtDestination) StartCoroutine(agent.UpdatePath(commanderAI));
                     }
                 }
             }


### PR DESCRIPTION
Pathfind from a safe node rather than teleporting to it, fixing the stay in place issue. Rename "npcs" to "player units." Lowered civilian and villain rings, they can now be seen more clearly regardless of their animations. Fix a hole in the navmesh, so they no longer generate a path through certain walls. Add animations to specific actions. Fixed the null gameobject error when starting.

We verified that it:
* builds
* runs smoother than before
* runs _in general_
* throws no errors on start